### PR TITLE
Update install and fix list-all for mac

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -84,7 +84,7 @@ get_download_url() {
 
 get_url_status() {
   local url="$1"
-  local status="$(curl -s -I "$url" | grep 'HTTP/1.1' | awk '{print $2}' | tail -n 1)"
+  local status="$(curl -s -I "$url" | grep 'HTTP/2' | awk '{print $2}' | tail -n 1)"
 
   echo "$status"
 }

--- a/bin/list-all
+++ b/bin/list-all
@@ -13,5 +13,5 @@ if sort --help | grep -q -- '-V'; then
 fi
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep 'name' | sed 's/^.*"name": "v\([^"]\+\)",/\1/' | $sort_cmd)
+versions=$(eval $cmd | grep 'name' | sed -r 's/^.*"name": "v([^"]+)",/\1/' | $sort_cmd)
 echo $versions


### PR DESCRIPTION
I am not an expert, but it seems like the `sed` command installed in macs uses an ancient version and without enabling the extended syntax does not recognise the `\1` syntax so the `list-all.sh` script displays the sbt versions as `"name":"<VERSION>"` instead of simply `<VERSION>`


Also the `install.sh` script was expecting the gitlab response to be `HTTP/1.1` when now it's `HTTP/2` so I also updated that.

Source: https://unix.stackexchange.com/questions/345604/why-is-my-regex-not-working-using-sed-in-bash-script-on-mac-osx